### PR TITLE
Allow passing options to setCookie

### DIFF
--- a/app-addon/lib/cookie.js
+++ b/app-addon/lib/cookie.js
@@ -1,10 +1,10 @@
 import Em from 'ember';
 
 export default Em.Object.extend({
-  setCookie: function(key, value) {
+  setCookie: function(key, value, options) {
     return new Em.RSVP.Promise(function(resolve, reject) {
       try {
-        Em.$.cookie(key, value);
+        Em.$.cookie(key, value, options);
         Em.run(null, resolve);
       } catch(e) {
         Em.run(null, reject, e);


### PR DESCRIPTION
`$.cookie#setCookie` accepts useful options, e. g.:

```js
$.cookie('name', 'value', { expires: 7, path: '/' });
```

It's a shame that ember-cli-cookie does not support them.