### PR TITLE
Fix initializer deprecation warning for >= ember 2.1.0

### DIFF
--- a/app-addon/initializers/cookie.js
+++ b/app-addon/initializers/cookie.js
@@ -2,7 +2,8 @@ import Cookie from '../lib/cookie';
 
 export default {
   name: 'cookie',
-  initialize: function(container, app) {
+  initialize: function() {
+    var app = arguments[1] || arguments[0];
     app.register('cookie:main', Cookie);
   }
 };


### PR DESCRIPTION
Initializers now only take 1 argument (see http://emberjs.com/deprecations/v2.x/#toc_initializer-arity).  This commit is the suggested approach to support versions of Ember pre and post this change